### PR TITLE
Use AssetWriter and AssetReader for correct path access

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,9 +67,6 @@ impl SlippyTilesSettings {
     /// Used to initialize slippy tile settings without using default values.
     /// Will also create the tiles directory immediately.
     pub fn new(endpoint: &str, tiles_directory: &str) -> SlippyTilesSettings {
-        // Need to ensure tiles folder exists.
-        std::fs::create_dir_all(format!("assets/{tiles_directory}")).unwrap();
-
         SlippyTilesSettings {
             endpoint: endpoint.to_owned(),
             tiles_directory: PathBuf::from(tiles_directory),

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -132,6 +132,7 @@ async fn does_file_exist(asset_server: &AssetServer, filename: &str) -> bool {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn download_and_track_slippy_tile(
     spc: SlippyTileCoordinates,
     zoom_level: ZoomLevel,


### PR DESCRIPTION
Hello,

I noticed that `bevy_slippy_tiles` cannot find the correct `assets/` directory when working in a cargo workspace project. This PR addresses the issue by utilizing the `AssetServer` from Bevy. Please note that since `AssetReader` does not have an API to check if a file exists, we must open the file in a blocking manner.
