### PR TITLE
Add `TryFrom<u8>` Implementation for `ZoomLevel`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,13 @@ mod tests {
     }
 
     #[test]
+    fn test_zoom_level_try_from() {
+        assert_eq!(ZoomLevel::try_from(0), Ok(ZoomLevel::L0));
+        assert_eq!(ZoomLevel::try_from(25), Ok(ZoomLevel::L25));
+        assert_eq!(ZoomLevel::try_from(26), Err(()));
+    }
+
+    #[test]
     fn test_tile_size_new() {
         assert_eq!(TileSize::new(256), TileSize::Normal);
         assert_eq!(TileSize::new(512), TileSize::Large);

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,65 +1,57 @@
-/// The zoom level used when fetching tiles (0 <= zoom <= 25)
-#[derive(Eq, Hash, PartialEq, Clone, Copy, Debug)]
-pub enum ZoomLevel {
-    L0,
-    L1,
-    L2,
-    L3,
-    L4,
-    L5,
-    L6,
-    L7,
-    L8,
-    L9,
-    L10,
-    L11,
-    L12,
-    L13,
-    L14,
-    L15,
-    L16,
-    L17,
-    L18,
-    L19,
-    L20,
-    L21,
-    L22,
-    L23,
-    L24,
-    L25,
+macro_rules! generate_zoom_level {
+    { $( $name:ident => $val:literal, )+ } => {
+        /// The zoom level used when fetching tiles (0 <= zoom <= 25)
+        #[derive(Eq, Hash, PartialEq, Clone, Copy, Debug)]
+        pub enum ZoomLevel {
+            $( $name = $val, )+
+        }
+
+        impl ZoomLevel {
+            pub fn to_u8(&self) -> u8 {
+                *self as u8
+            }
+        }
+
+        impl TryFrom<u8> for ZoomLevel {
+            type Error = ();
+
+            fn try_from(v: u8) -> Result<Self, Self::Error> {
+                match v {
+                    $( $val => Ok(Self::$name), )+
+                    _ => Err(()),
+                }
+            }
+        }
+    };
 }
 
-impl ZoomLevel {
-    pub fn to_u8(&self) -> u8 {
-        match self {
-            ZoomLevel::L0 => 0,
-            ZoomLevel::L1 => 1,
-            ZoomLevel::L2 => 2,
-            ZoomLevel::L3 => 3,
-            ZoomLevel::L4 => 4,
-            ZoomLevel::L5 => 5,
-            ZoomLevel::L6 => 6,
-            ZoomLevel::L7 => 7,
-            ZoomLevel::L8 => 8,
-            ZoomLevel::L9 => 9,
-            ZoomLevel::L10 => 10,
-            ZoomLevel::L11 => 11,
-            ZoomLevel::L12 => 12,
-            ZoomLevel::L13 => 13,
-            ZoomLevel::L14 => 14,
-            ZoomLevel::L15 => 15,
-            ZoomLevel::L16 => 16,
-            ZoomLevel::L17 => 17,
-            ZoomLevel::L18 => 18,
-            ZoomLevel::L19 => 19,
-            ZoomLevel::L20 => 20,
-            ZoomLevel::L21 => 21,
-            ZoomLevel::L22 => 22,
-            ZoomLevel::L23 => 23,
-            ZoomLevel::L24 => 24,
-            ZoomLevel::L25 => 25,
-        }
-    }
+generate_zoom_level! {
+    L0 => 0,
+    L1 => 1,
+    L2 => 2,
+    L3 => 3,
+    L4 => 4,
+    L5 => 5,
+    L6 => 6,
+    L7 => 7,
+    L8 => 8,
+    L9 => 9,
+    L10 => 10,
+    L11 => 11,
+    L12 => 12,
+    L13 => 13,
+    L14 => 14,
+    L15 => 15,
+    L16 => 16,
+    L17 => 17,
+    L18 => 18,
+    L19 => 19,
+    L20 => 20,
+    L21 => 21,
+    L22 => 22,
+    L23 => 23,
+    L24 => 24,
+    L25 => 25,
 }
 
 /// The size of the tiles being requested - either 256px (Normal), 512px (Large), or 768px (VeryLarge).


### PR DESCRIPTION
Hello,

In my project, I’m using `u8` values to represent zoom levels for a slippy map, as this makes it straightforward to increment ( `zoom += 1` ), decrement, or specify zoom levels directly using raw integers, such as from command-line arguments ( `myapp --zoom=12` ).

However, I noticed that `ZoomLevel` currently lacks a way to be constructed directly from a raw `u8` value. To address this, I’ve implemented the `TryFrom<u8>` trait for `ZoomLevel`, allowing for conversions like:

```rust
let zoom: ZoomLevel = 12u8.try_into()?;
```

Additionally, I’ve introduced a new macro, `generate_zoom_level`, to simplify the boilerplate code involved in defining the `ZoomLevel` enum. This macro makes it easier to manage and extend the enum when dealing with large ranges of zoom levels.

I hope you find this contribution useful, and I look forward to your feedback.
