### PR TITLE
add display feature to disable tile rendering

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,11 @@ jobs:
   test:
     name: Test Suite
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        features:
+          - "--all-features"
+          - "--no-default-features"
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -31,7 +36,7 @@ jobs:
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install pkg-config libx11-dev libasound2-dev libudev-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev
       - name: Run cargo test
-        run: cargo test
+        run: cargo test ${{ matrix.features }}
 
   # Run cargo clippy -- -D warnings
   clippy_check:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,7 @@ googleprojection = "1.2"
 [[example]]
 name = "simple"
 path = "examples/simple.rs"
+
+[[example]]
+name = "interactive"
+path = "examples/interactive.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,10 @@ description = "Provides slippy tile fetching functionality in the Bevy game engi
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/edouardpoitras/bevy_slippy_tiles"
 
+[features]
+default = ["display"]
+display = []
+
 [dependencies]
 bevy = "0.15"
 ehttp = { version = "0.5", features = ["native-async"] }
@@ -14,7 +18,9 @@ googleprojection = "1.2"
 [[example]]
 name = "simple"
 path = "examples/simple.rs"
+required-features = ["display"]
 
 [[example]]
 name = "interactive"
 path = "examples/interactive.rs"
+required-features = ["display"]

--- a/README.md
+++ b/README.md
@@ -94,6 +94,17 @@ SlippyTilesSettings {
 }
 ```
 
+### Cargo Features
+
+This crate provides optional Cargo features for customization:
+
+- **`display`** (enabled by default): Enables automatic Slippy tile rendering
+
+To disable this feature:
+
+```sh
+cargo build --no-default-features
+```
 
 ## Bevy Compatibility
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod constants;
 mod coordinates;
+#[cfg(feature = "display")]
 mod display;
 mod download;
 mod settings;
@@ -10,6 +11,7 @@ mod types;
 
 pub use constants::*;
 pub use coordinates::*;
+#[cfg(feature = "display")]
 pub use display::*;
 pub use download::*;
 pub use settings::*;
@@ -28,8 +30,10 @@ impl Plugin for SlippyTilesPlugin {
             .add_event::<DownloadSlippyTilesEvent>()
             .add_event::<SlippyTileDownloadedEvent>()
             .add_systems(Update, systems::download_slippy_tiles)
-            .add_systems(Update, systems::download_slippy_tiles_completed)
-            .add_systems(Update, display::display_tiles);
+            .add_systems(Update, systems::download_slippy_tiles_completed);
+
+        #[cfg(feature = "display")]
+        app.add_systems(Update, display::display_tiles);
     }
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,63 +1,75 @@
 use bevy::prelude::{Resource, Transform};
 use std::{path::PathBuf, time::Duration};
 
-/// Type used to dictate various settings for this crate.
-///
-/// Download Settings:
-/// - `endpoint` - Tile server endpoint (example: <https://tile.openstreetmap.org>)
-/// - `tiles_directory` - The folder that all tiles will be stored in
-/// - `max_concurrent_downloads` - Maximum number of concurrent tile downloads
-/// - `max_retries` - Maximum number of retry attempts for failed downloads
-/// - `rate_limit_requests` - Maximum number of requests allowed within the rate limit window
-/// - `rate_limit_window` - Duration of the rate limit window
-///
-/// Display Settings:
-/// - `reference_latitude` - Latitude that maps to Transform(0,0,0) or transform_offset if specified
-/// - `reference_longitude` - Longitude that maps to Transform(0,0,0) or transform_offset if specified
-/// - `transform_offset` - Optional offset from 0,0 where the reference coordinates should appear
-/// - `z_layer` - Z coordinate for rendered tiles
-/// - `auto_render` - Whether tiles should be automatically rendered
-#[derive(Clone, Resource)]
-pub struct SlippyTilesSettings {
-    // Download settings
-    pub endpoint: String,
-    pub tiles_directory: PathBuf,
-    pub max_concurrent_downloads: usize,
-    pub max_retries: u32,
-    pub rate_limit_requests: usize,
-    pub rate_limit_window: Duration,
+macro_rules! generate_slippy_tiles_settings {
+    ($(($name:ident, $type:ty, $default:expr)),* $(,)?) => {
+        /// Type used to dictate various settings for this crate.
+        ///
+        /// Download Settings:
+        /// - `endpoint` - Tile server endpoint (example: <https://tile.openstreetmap.org>)
+        /// - `tiles_directory` - The folder that all tiles will be stored in
+        /// - `max_concurrent_downloads` - Maximum number of concurrent tile downloads
+        /// - `max_retries` - Maximum number of retry attempts for failed downloads
+        /// - `rate_limit_requests` - Maximum number of requests allowed within the rate limit window
+        /// - `rate_limit_window` - Duration of the rate limit window
+        ///
+        /// Display Settings:
+        /// - `reference_latitude` - Latitude that maps to Transform(0,0,0) or transform_offset if specified
+        /// - `reference_longitude` - Longitude that maps to Transform(0,0,0) or transform_offset if specified
+        /// - `transform_offset` - Optional offset from 0,0 where the reference coordinates should appear
+        /// - `z_layer` - Z coordinate for rendered tiles
+        /// - `auto_render` - Whether tiles should be automatically rendered
+        #[derive(Clone, Resource)]
+        pub struct SlippyTilesSettings {
+            // Download settings
+            pub endpoint: String,
+            pub tiles_directory: PathBuf,
+            pub max_concurrent_downloads: usize,
+            pub max_retries: u32,
+            pub rate_limit_requests: usize,
+            pub rate_limit_window: Duration,
 
-    // Display settings
-    pub reference_latitude: f64,
-    pub reference_longitude: f64,
-    pub transform_offset: Option<Transform>,
-    pub z_layer: f32,
-    pub auto_render: bool,
-}
-
-impl SlippyTilesSettings {
-    pub fn get_tiles_directory_string(&self) -> String {
-        self.tiles_directory.as_path().to_str().unwrap().to_string()
-    }
-}
-
-impl Default for SlippyTilesSettings {
-    fn default() -> Self {
-        Self {
-            // Download defaults
-            endpoint: "https://tile.openstreetmap.org".into(),
-            tiles_directory: PathBuf::from("tiles/"),
-            max_concurrent_downloads: 4,
-            max_retries: 3,
-            rate_limit_requests: 10,
-            rate_limit_window: Duration::from_secs(1),
-
-            // Display defaults
-            reference_latitude: 0.0,
-            reference_longitude: 0.0,
-            transform_offset: None,
-            z_layer: 0.0,
-            auto_render: true,
+            // Other settings
+            $(
+                pub $name: $type,
+            )*
         }
-    }
+
+        impl SlippyTilesSettings {
+            pub fn get_tiles_directory_string(&self) -> String {
+                self.tiles_directory.as_path().to_str().unwrap().to_string()
+            }
+        }
+
+        impl Default for SlippyTilesSettings {
+            fn default() -> Self {
+                Self {
+                    // Download defaults
+                    endpoint: "https://tile.openstreetmap.org".into(),
+                    tiles_directory: PathBuf::from("tiles/"),
+                    max_concurrent_downloads: 4,
+                    max_retries: 3,
+                    rate_limit_requests: 10,
+                    rate_limit_window: Duration::from_secs(1),
+
+                    // Other defaults
+                    $(
+                        $name: $default,
+                    )*
+                }
+            }
+        }
+    };
 }
+
+#[cfg(feature = "display")]
+generate_slippy_tiles_settings!(
+    // Display settings and defaults
+    (reference_latitude, f64, 0.0),
+    (reference_longitude, f64, 0.0),
+    (transform_offset, Option<Transform>, None),
+    (z_layer, f32, 0.0),
+    (auto_render, bool, true),
+);
+#[cfg(not(feature = "display"))]
+generate_slippy_tiles_settings!();


### PR DESCRIPTION
Hello,

This PR introduces the `display` Cargo feature to allow disabling tile rendering entirely. While setting `auto_render = false` prevents rendering, the `display_tiles` system still runs every frame. With this feature disabled, all rendering-related logic is excluded from the build.

An alternative approach could be splitting `SlippyTilesPlugin` into `SlippyTilesCorePlugin` for downloading and `SlippyTilesDisplayPlugin` for rendering, but this PR keeps the existing structure intact.

GitHub Actions have also been updated to test with and without display, but since workflows don’t run on forks, adjustments may be needed by the repository owner.
