### PR TITLE
Rename `*Event` to `*Message` to align with Bevy 0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_slippy_tiles"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-lock",
  "bevy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_slippy_tiles"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 description = "Provides slippy tile fetching functionality in the Bevy game engine"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 A helper bevy plugin to handle downloading and displaying OpenStreetMap-compliant [slippy tiles](https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames).
 
-[`DownloadSlippyTilesEvent`] can be fired to request one or more slippy tile downloads.
+[`DownloadSlippyTilesMessage`] can be fired to request one or more slippy tile downloads.
 
-[`SlippyTileDownloadedEvent`] is fired when a requested slippy tile has been retrieved successfully. The file path is stored in the event and can be used with the asset loader.
+[`SlippyTileDownloadedMessage`] is fired when a requested slippy tile has been retrieved successfully. The file path is stored in the message and can be used with the asset loader.
 
 ## Features
 
@@ -47,16 +47,16 @@ fn main() {
         .run();
 }
 
-fn request_slippy_tiles(mut commands: Commands, mut download_slippy_tile_events: MessageWriter<DownloadSlippyTilesEvent>) {
+fn request_slippy_tiles(mut commands: Commands, mut download_slippy_tile_messages: MessageWriter<DownloadSlippyTilesMessage>) {
     commands.spawn(Camera2dBundle::default());
-    let slippy_tile_event = DownloadSlippyTilesEvent {
+    let slippy_tile_message = DownloadSlippyTilesMessage {
         tile_size: TileSize::Normal,    // Size of tiles - Normal = 256px, Large = 512px
         zoom_level: ZoomLevel::L18,     // Map zoom level (L0 = entire world, L19 = closest)
         coordinates: Coordinates::from_latitude_longitude(LATITUDE, LONGITUDE),
         radius: Radius(2),              // Request surrounding tiles (2 = 25 tiles total)
         use_cache: true,                // Use cached tiles if available
     };
-    download_slippy_tile_events.send(slippy_tile_event);
+    download_slippy_tile_messages.send(slippy_tile_message);
 }
 ```
 

--- a/examples/interactive.rs
+++ b/examples/interactive.rs
@@ -14,7 +14,7 @@ use bevy::{
 };
 use bevy_slippy_tiles::{
     world_coords_to_world_pixel, world_pixel_to_world_coords, Coordinates,
-    DownloadSlippyTilesEvent, MapTile, Radius, SlippyTilesPlugin, SlippyTilesSettings, TileSize,
+    DownloadSlippyTilesMessage, MapTile, Radius, SlippyTilesPlugin, SlippyTilesSettings, TileSize,
     ZoomLevel,
 };
 
@@ -79,7 +79,7 @@ fn main() {
 /// 3. Sets up a radius of tiles around the center point for better coverage
 fn setup(
     mut commands: Commands,
-    mut download_slippy_tile_events: MessageWriter<DownloadSlippyTilesEvent>,
+    mut download_slippy_tile_events: MessageWriter<DownloadSlippyTilesMessage>,
     current_zoom: Res<CurrentZoom>,
 ) {
     commands.spawn(Camera2d::default());
@@ -89,7 +89,7 @@ fn setup(
         (LATITUDE, LONGITUDE)
     );
 
-    let slippy_tile_event = DownloadSlippyTilesEvent {
+    let slippy_tile_event = DownloadSlippyTilesMessage {
         tile_size: TileSize::Normal,
         zoom_level: current_zoom.level,
         coordinates: Coordinates::from_latitude_longitude(LATITUDE, LONGITUDE),
@@ -161,7 +161,7 @@ fn cleanup_tiles(
 fn handle_zoom(
     mut mouse_wheel: MessageReader<MouseWheel>,
     mut current_zoom: ResMut<CurrentZoom>,
-    mut download_slippy_tile_events: MessageWriter<DownloadSlippyTilesEvent>,
+    mut download_slippy_tile_events: MessageWriter<DownloadSlippyTilesMessage>,
     camera_query: Query<(&Camera, &GlobalTransform)>,
     q_window: Query<&Window, With<PrimaryWindow>>,
     settings: Res<SlippyTilesSettings>,
@@ -227,7 +227,7 @@ fn handle_zoom(
                     current_zoom.last_zoom_time = time.elapsed_secs();
 
                     // Request new tiles at the new zoom level
-                    let slippy_tile_event = DownloadSlippyTilesEvent {
+                    let slippy_tile_event = DownloadSlippyTilesMessage {
                         tile_size: TileSize::Normal,
                         zoom_level: current_zoom.level,
                         coordinates: Coordinates::from_latitude_longitude(

--- a/examples/interactive.rs
+++ b/examples/interactive.rs
@@ -79,7 +79,7 @@ fn main() {
 /// 3. Sets up a radius of tiles around the center point for better coverage
 fn setup(
     mut commands: Commands,
-    mut download_slippy_tile_events: MessageWriter<DownloadSlippyTilesMessage>,
+    mut download_slippy_tile_messages: MessageWriter<DownloadSlippyTilesMessage>,
     current_zoom: Res<CurrentZoom>,
 ) {
     commands.spawn(Camera2d::default());
@@ -89,14 +89,14 @@ fn setup(
         (LATITUDE, LONGITUDE)
     );
 
-    let slippy_tile_event = DownloadSlippyTilesMessage {
+    let slippy_tile_message = DownloadSlippyTilesMessage {
         tile_size: TileSize::Normal,
         zoom_level: current_zoom.level,
         coordinates: Coordinates::from_latitude_longitude(LATITUDE, LONGITUDE),
         radius: Radius(2),
         use_cache: true,
     };
-    download_slippy_tile_events.write(slippy_tile_event);
+    download_slippy_tile_messages.write(slippy_tile_message);
 }
 
 /// System handling map panning functionality using the left mouse button
@@ -161,7 +161,7 @@ fn cleanup_tiles(
 fn handle_zoom(
     mut mouse_wheel: MessageReader<MouseWheel>,
     mut current_zoom: ResMut<CurrentZoom>,
-    mut download_slippy_tile_events: MessageWriter<DownloadSlippyTilesMessage>,
+    mut download_slippy_tile_messages: MessageWriter<DownloadSlippyTilesMessage>,
     camera_query: Query<(&Camera, &GlobalTransform)>,
     q_window: Query<&Window, With<PrimaryWindow>>,
     settings: Res<SlippyTilesSettings>,
@@ -227,7 +227,7 @@ fn handle_zoom(
                     current_zoom.last_zoom_time = time.elapsed_secs();
 
                     // Request new tiles at the new zoom level
-                    let slippy_tile_event = DownloadSlippyTilesMessage {
+                    let slippy_tile_message = DownloadSlippyTilesMessage {
                         tile_size: TileSize::Normal,
                         zoom_level: current_zoom.level,
                         coordinates: Coordinates::from_latitude_longitude(
@@ -237,7 +237,7 @@ fn handle_zoom(
                         radius: Radius(2),
                         use_cache: true,
                     };
-                    download_slippy_tile_events.write(slippy_tile_event);
+                    download_slippy_tile_messages.write(slippy_tile_message);
                 }
             }
         }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 use bevy_slippy_tiles::{
-    Coordinates, DownloadSlippyTilesEvent, Radius, SlippyTilesPlugin, SlippyTilesSettings,
+    Coordinates, DownloadSlippyTilesMessage, Radius, SlippyTilesPlugin, SlippyTilesSettings,
     TileSize, ZoomLevel,
 };
 
@@ -22,14 +22,14 @@ fn main() {
 
 fn request_slippy_tiles(
     mut commands: Commands,
-    mut download_slippy_tile_events: MessageWriter<DownloadSlippyTilesEvent>,
+    mut download_slippy_tile_events: MessageWriter<DownloadSlippyTilesMessage>,
 ) {
     commands.spawn(Camera2d::default());
     info!(
         "Requesting slippy tile for latitude/longitude: {:?}",
         (LATITUDE, LONGITUDE)
     );
-    let slippy_tile_event = DownloadSlippyTilesEvent {
+    let slippy_tile_event = DownloadSlippyTilesMessage {
         tile_size: TileSize::Normal, // Size of tiles - Normal = 256px, Large = 512px (not all tile servers).
         zoom_level: ZoomLevel::L18, // Map zoom level (L0 = entire world, L19 = closest zoom level).
         coordinates: Coordinates::from_latitude_longitude(LATITUDE, LONGITUDE),

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -22,19 +22,19 @@ fn main() {
 
 fn request_slippy_tiles(
     mut commands: Commands,
-    mut download_slippy_tile_events: MessageWriter<DownloadSlippyTilesMessage>,
+    mut download_slippy_tile_messages: MessageWriter<DownloadSlippyTilesMessage>,
 ) {
     commands.spawn(Camera2d::default());
     info!(
         "Requesting slippy tile for latitude/longitude: {:?}",
         (LATITUDE, LONGITUDE)
     );
-    let slippy_tile_event = DownloadSlippyTilesMessage {
+    let slippy_tile_message = DownloadSlippyTilesMessage {
         tile_size: TileSize::Normal, // Size of tiles - Normal = 256px, Large = 512px (not all tile servers).
         zoom_level: ZoomLevel::L18, // Map zoom level (L0 = entire world, L19 = closest zoom level).
         coordinates: Coordinates::from_latitude_longitude(LATITUDE, LONGITUDE),
         radius: Radius(2), // Request one layer of surrounding tiles (2 = two layers of surrounding tiles - 25 total, 3 = three layers of surrounding tiles - 49 total, etc).
         use_cache: true, // Don't make request if already requested previously, or if file already exists in tiles directory.
     };
-    download_slippy_tile_events.write(slippy_tile_event);
+    download_slippy_tile_messages.write(slippy_tile_message);
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,5 +1,5 @@
 use crate::{
-    world_coords_to_world_pixel, LatitudeLongitudeCoordinates, SlippyTileDownloadedEvent,
+    world_coords_to_world_pixel, LatitudeLongitudeCoordinates, SlippyTileDownloadedMessage,
     SlippyTilesSettings,
 };
 use bevy::prelude::*;
@@ -13,7 +13,7 @@ pub fn display_tiles(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
     settings: Res<SlippyTilesSettings>,
-    mut tile_events: MessageReader<SlippyTileDownloadedEvent>,
+    mut tile_events: MessageReader<SlippyTileDownloadedMessage>,
 ) {
     // Skip if auto-render is disabled
     if !settings.auto_render {

--- a/src/display.rs
+++ b/src/display.rs
@@ -13,31 +13,31 @@ pub fn display_tiles(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
     settings: Res<SlippyTilesSettings>,
-    mut tile_events: MessageReader<SlippyTileDownloadedMessage>,
+    mut tile_messages: MessageReader<SlippyTileDownloadedMessage>,
 ) {
     // Skip if auto-render is disabled
     if !settings.auto_render {
         return;
     }
 
-    for event in tile_events.read() {
+    for message in tile_messages.read() {
         // Convert reference coordinates to pixel coordinates
         let reference_point = LatitudeLongitudeCoordinates {
             latitude: settings.reference_latitude,
             longitude: settings.reference_longitude,
         };
         let (ref_x, ref_y) =
-            world_coords_to_world_pixel(&reference_point, event.tile_size, event.zoom_level);
+            world_coords_to_world_pixel(&reference_point, message.tile_size, message.zoom_level);
 
         // Convert tile coordinates to pixel coordinates
-        let current_coords = match event.coordinates {
+        let current_coords = match message.coordinates {
             crate::Coordinates::LatitudeLongitude(coords) => coords,
             crate::Coordinates::SlippyTile(coords) => {
-                coords.to_latitude_longitude(event.zoom_level)
+                coords.to_latitude_longitude(message.zoom_level)
             },
         };
         let (tile_x, tile_y) =
-            world_coords_to_world_pixel(&current_coords, event.tile_size, event.zoom_level);
+            world_coords_to_world_pixel(&current_coords, message.tile_size, message.zoom_level);
 
         // Calculate offset from reference point
         let mut transform_x = (tile_x - ref_x) as f32;
@@ -51,7 +51,7 @@ pub fn display_tiles(
 
         // Spawn the tile sprite
         commands.spawn((
-            Sprite::from_image(asset_server.load(event.path.clone())),
+            Sprite::from_image(asset_server.load(message.path.clone())),
             Transform::from_xyz(transform_x, transform_y, settings.z_layer),
             MapTile,
         ));

--- a/src/download.rs
+++ b/src/download.rs
@@ -1,8 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use bevy::{
-    ecs::message::Message, prelude::Resource, tasks::Task
-};
+use bevy::{ecs::message::Message, prelude::Resource, tasks::Task};
 use bevy_platform::collections::HashMap;
 
 use crate::coordinates::{Coordinates, SlippyTileCoordinates};
@@ -149,7 +147,7 @@ impl Default for SlippyTileDownloadTasks {
 
 /// Users send these events to request slippy tile downloads.
 #[derive(Debug, Message)]
-pub struct DownloadSlippyTilesEvent {
+pub struct DownloadSlippyTilesMessage {
     pub tile_size: TileSize,
     pub zoom_level: ZoomLevel,
     pub coordinates: Coordinates,
@@ -159,16 +157,20 @@ pub struct DownloadSlippyTilesEvent {
     pub use_cache: bool,
 }
 
-impl DownloadSlippyTilesEvent {
+impl DownloadSlippyTilesMessage {
     pub fn get_slippy_tile_coordinates(&self) -> SlippyTileCoordinates {
         self.coordinates
             .get_slippy_tile_coordinates(self.zoom_level)
     }
 }
 
+/// This is deprecated. See [`DownloadSlippyTilesMessage`](crate::download::DownloadSlippyTilesMessage)
+#[deprecated(since = "0.10.1", note = "Renamed to `DownloadSlippyTilesMessage`.")]
+pub type DownloadSlippyTilesEvent = DownloadSlippyTilesMessage;
+
 /// The library will generate these events upon successful slippy tile downloads.
 #[derive(Debug, Message)]
-pub struct SlippyTileDownloadedEvent {
+pub struct SlippyTileDownloadedMessage {
     /// The [`TileSize`] used for this downloaded slippy tile.
     pub tile_size: TileSize,
     /// The [`ZoomLevel`] used for this downloaded slippy tile.
@@ -179,9 +181,13 @@ pub struct SlippyTileDownloadedEvent {
     pub path: PathBuf,
 }
 
-impl SlippyTileDownloadedEvent {
+impl SlippyTileDownloadedMessage {
     pub fn get_slippy_tile_coordinates(&self) -> SlippyTileCoordinates {
         self.coordinates
             .get_slippy_tile_coordinates(self.zoom_level)
     }
 }
+
+/// This is deprecated. See [`SlippyTileDownloadedMessage`](crate::download::SlippyTileDownloadedMessage)
+#[deprecated(since = "0.10.1", note = "Renamed to `SlippyTileDownloadedMessage`.")]
+pub type SlippyTileDownloadedEvent = SlippyTileDownloadedMessage;

--- a/src/download.rs
+++ b/src/download.rs
@@ -145,7 +145,7 @@ impl Default for SlippyTileDownloadTasks {
     }
 }
 
-/// Users send these events to request slippy tile downloads.
+/// Users send these messages to request slippy tile downloads.
 #[derive(Debug, Message)]
 pub struct DownloadSlippyTilesMessage {
     pub tile_size: TileSize,
@@ -168,7 +168,7 @@ impl DownloadSlippyTilesMessage {
 #[deprecated(since = "0.10.1", note = "Renamed to `DownloadSlippyTilesMessage`.")]
 pub type DownloadSlippyTilesEvent = DownloadSlippyTilesMessage;
 
-/// The library will generate these events upon successful slippy tile downloads.
+/// The library will generate these messages upon successful slippy tile downloads.
 #[derive(Debug, Message)]
 pub struct SlippyTileDownloadedMessage {
     /// The [`TileSize`] used for this downloaded slippy tile.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,8 @@ impl Plugin for SlippyTilesPlugin {
         app.insert_resource(SlippyTileDownloadStatus::new())
             .insert_resource(SlippyTileDownloadTasks::new())
             .insert_resource(systems::DownloadRateLimiter::default())
-            .add_message::<DownloadSlippyTilesEvent>()
-            .add_message::<SlippyTileDownloadedEvent>()
+            .add_message::<DownloadSlippyTilesMessage>()
+            .add_message::<SlippyTileDownloadedMessage>()
             .add_systems(Startup, systems::initialize_semaphore)
             .add_systems(Update, systems::download_slippy_tiles)
             .add_systems(Update, systems::download_slippy_tiles_completed);

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -121,7 +121,7 @@ pub(crate) fn initialize_semaphore(
     commands.insert_resource(semaphore);
 }
 
-/// System that listens for DownloadSlippyTiles events and submits individual tile requests in separate threads.
+/// System that listens for DownloadSlippyTiles messages and submits individual tile requests in separate threads.
 pub fn download_slippy_tiles(
     mut download_slippy_tile_messages: MessageReader<DownloadSlippyTilesMessage>,
     slippy_tiles_settings: Res<SlippyTilesSettings>,
@@ -457,7 +457,7 @@ fn spawn_fake_slippy_tile_download_task(filename: String) -> Task<SlippyTileDown
     })
 }
 
-/// System that checks for completed slippy tile downloads and notifies via a SlippyTileDownloadedEvent event.
+/// System that checks for completed slippy tile downloads and notifies via a SlippyTileDownloadedMessage message.
 pub fn download_slippy_tiles_completed(
     mut slippy_tile_download_status: ResMut<SlippyTileDownloadStatus>,
     mut slippy_tile_download_tasks: ResMut<SlippyTileDownloadTasks>,
@@ -477,7 +477,7 @@ pub fn download_slippy_tiles_completed(
                     load_status: DownloadStatus::Downloaded,
                 },
             );
-            // Notify any event consumers.
+            // Notify any message consumers.
             slippy_tile_downloaded_messages.write(SlippyTileDownloadedMessage {
                 zoom_level: stdtk.zoom_level,
                 tile_size: stdtk.tile_size,

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -123,7 +123,7 @@ pub(crate) fn initialize_semaphore(
 
 /// System that listens for DownloadSlippyTiles events and submits individual tile requests in separate threads.
 pub fn download_slippy_tiles(
-    mut download_slippy_tile_events: MessageReader<DownloadSlippyTilesMessage>,
+    mut download_slippy_tile_messages: MessageReader<DownloadSlippyTilesMessage>,
     slippy_tiles_settings: Res<SlippyTilesSettings>,
     mut slippy_tile_download_status: ResMut<SlippyTileDownloadStatus>,
     mut slippy_tile_download_tasks: ResMut<SlippyTileDownloadTasks>,
@@ -140,7 +140,7 @@ pub fn download_slippy_tiles(
         &slippy_tiles_settings,
     );
 
-    for download_slippy_tile in download_slippy_tile_events.read() {
+    for download_slippy_tile in download_slippy_tile_messages.read() {
         let radius = download_slippy_tile.radius.0;
         let slippy_tile_coords = download_slippy_tile.get_slippy_tile_coordinates();
 
@@ -461,7 +461,7 @@ fn spawn_fake_slippy_tile_download_task(filename: String) -> Task<SlippyTileDown
 pub fn download_slippy_tiles_completed(
     mut slippy_tile_download_status: ResMut<SlippyTileDownloadStatus>,
     mut slippy_tile_download_tasks: ResMut<SlippyTileDownloadTasks>,
-    mut slippy_tile_downloaded_events: MessageWriter<SlippyTileDownloadedMessage>,
+    mut slippy_tile_downloaded_messages: MessageWriter<SlippyTileDownloadedMessage>,
 ) {
     let mut to_be_removed: Vec<SlippyTileDownloadTaskKey> = Vec::new();
     for (stdtk, task) in slippy_tile_download_tasks.0.iter_mut() {
@@ -478,7 +478,7 @@ pub fn download_slippy_tiles_completed(
                 },
             );
             // Notify any event consumers.
-            slippy_tile_downloaded_events.write(SlippyTileDownloadedMessage {
+            slippy_tile_downloaded_messages.write(SlippyTileDownloadedMessage {
                 zoom_level: stdtk.zoom_level,
                 tile_size: stdtk.tile_size,
                 coordinates: Coordinates::from_slippy_tile_coordinates(


### PR DESCRIPTION
Hello,

According to the recent Bevy migration guide, we should no longer use `Event` for buffered events. This PR updates the codebase to use the new `Message` terminology. This resolves the terminology mismatch in signatures like `MessageWriter<DownloadSlippyTilesEvent>` .

Note that this PR doesn't remove the old `Event` names; it marks them as `#[deprecated]` to maintain backward compatibility, similar to the approach taken in upstream `bevy` crates.

https://github.com/bevyengine/bevy/blob/706fdd9800c4bf335d67f127ff6e5a93deadabb9/crates/bevy_ecs/src/event/mod.rs#L340-L366