### PR TITLE
enable doctests for `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Here's a snippet showing how to download and display map tiles at a specific loc
 
 Run with: `cargo run --example simple`
 
-```rust,ignore
+```rust,no_run
 use bevy::prelude::*;
 use bevy_slippy_tiles::*;
 
@@ -76,7 +76,7 @@ The plugin uses reasonable defaults but can be configured:
 - `z_layer`: Z coordinate for rendered tiles, useful for layering with other sprites
 - `auto_render`: Toggle automatic tile rendering (disable for manual control)
 
-```rust,ignore
+```rust,no_run
 SlippyTilesSettings {
     endpoint: "https://tile.openstreetmap.org".into(), // Tile server endpoint
     tiles_directory: "tiles/".into(), // Cache directory

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ fn main() {
 }
 
 fn request_slippy_tiles(mut commands: Commands, mut download_slippy_tile_messages: MessageWriter<DownloadSlippyTilesMessage>) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d::default());
     let slippy_tile_message = DownloadSlippyTilesMessage {
         tile_size: TileSize::Normal,    // Size of tiles - Normal = 256px, Large = 512px
         zoom_level: ZoomLevel::L18,     // Map zoom level (L0 = entire world, L19 = closest)
@@ -56,7 +56,7 @@ fn request_slippy_tiles(mut commands: Commands, mut download_slippy_tile_message
         radius: Radius(2),              // Request surrounding tiles (2 = 25 tiles total)
         use_cache: true,                // Use cached tiles if available
     };
-    download_slippy_tile_messages.send(slippy_tile_message);
+    download_slippy_tile_messages.write(slippy_tile_message);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Here's a snippet showing how to download and display map tiles at a specific loc
 Run with: `cargo run --example simple`
 
 ```rust,no_run
+# #[cfg(feature = "display")]
+# {
 use bevy::prelude::*;
 use bevy_slippy_tiles::*;
 
@@ -58,6 +60,7 @@ fn request_slippy_tiles(mut commands: Commands, mut download_slippy_tile_message
     };
     download_slippy_tile_messages.write(slippy_tile_message);
 }
+# }
 ```
 
 ## Configuration
@@ -80,6 +83,8 @@ The plugin uses reasonable defaults but can be configured:
 # use bevy::prelude::Transform;
 # use std::time::Duration;
 # use bevy_slippy_tiles::SlippyTilesSettings;
+# #[cfg(feature = "display")]
+# {
 SlippyTilesSettings {
     endpoint: "https://tile.openstreetmap.org".into(), // Tile server endpoint
     tiles_directory: "tiles/".into(), // Cache directory
@@ -96,6 +101,7 @@ SlippyTilesSettings {
     auto_render: true, // Enable automatic rendering (default: true)
 }
 # ;
+# }
 ```
 
 ### Cargo Features

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ The plugin uses reasonable defaults but can be configured:
 - `auto_render`: Toggle automatic tile rendering (disable for manual control)
 
 ```rust,no_run
+# use bevy::prelude::Transform;
+# use std::time::Duration;
+# use bevy_slippy_tiles::SlippyTilesSettings;
 SlippyTilesSettings {
     endpoint: "https://tile.openstreetmap.org".into(), // Tile server endpoint
     tiles_directory: "tiles/".into(), // Cache directory
@@ -92,6 +95,7 @@ SlippyTilesSettings {
     z_layer: 1.0, // Z coordinate for tiles (default: 0.0)
     auto_render: true, // Enable automatic rendering (default: true)
 }
+# ;
 ```
 
 ### Cargo Features


### PR DESCRIPTION
Hello,

I noticed that the sample code in `README.md` is a bit broken. It uses `ignore` for the code blocks right now, but it is better to use `no_run` to check compilation.

This PR enables doctests for `README.md` and fixes the issues.
