### PR TITLE
enable `clippy` for examples

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install pkg-config libx11-dev libasound2-dev libudev-dev libwayland-dev
       - name: Run clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
 
   # Run cargo fmt --all -- --check
   format:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ fn main() {
 }
 
 fn request_slippy_tiles(mut commands: Commands, mut download_slippy_tile_messages: MessageWriter<DownloadSlippyTilesMessage>) {
-    commands.spawn(Camera2d::default());
+    commands.spawn(Camera2d);
     let slippy_tile_message = DownloadSlippyTilesMessage {
         tile_size: TileSize::Normal,    // Size of tiles - Normal = 256px, Large = 512px
         zoom_level: ZoomLevel::L18,     // Map zoom level (L0 = entire world, L19 = closest)

--- a/examples/interactive.rs
+++ b/examples/interactive.rs
@@ -82,7 +82,7 @@ fn setup(
     mut download_slippy_tile_messages: MessageWriter<DownloadSlippyTilesMessage>,
     current_zoom: Res<CurrentZoom>,
 ) {
-    commands.spawn(Camera2d::default());
+    commands.spawn(Camera2d);
 
     info!(
         "Requesting slippy tile for latitude/longitude: {:?}",

--- a/examples/interactive.rs
+++ b/examples/interactive.rs
@@ -187,9 +187,8 @@ fn handle_zoom(
             // Convert cursor position to world coordinates before zoom
             if let Some(cursor_pos) = q_window.single().unwrap().cursor_position() {
                 let (camera, camera_transform) = camera_query.single().unwrap();
-                if let Some(cursor_world_pos) = camera
-                    .viewport_to_world_2d(camera_transform, cursor_pos)
-                    .ok()
+                if let Ok(cursor_world_pos) =
+                    camera.viewport_to_world_2d(camera_transform, cursor_pos)
                 {
                     // Get the reference point's pixel coordinates
                     let (ref_x, ref_y) = world_coords_to_world_pixel(
@@ -263,9 +262,8 @@ fn handle_click(
         let window = q_window.single().unwrap();
 
         if let Some(cursor_position) = window.cursor_position() {
-            if let Some(world_2d_position) = camera
-                .viewport_to_world_2d(camera_transform, cursor_position)
-                .ok()
+            if let Ok(world_2d_position) =
+                camera.viewport_to_world_2d(camera_transform, cursor_position)
             {
                 // Convert map position to world coordinates considering the reference point and offset
                 let offset = settings

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -24,7 +24,7 @@ fn request_slippy_tiles(
     mut commands: Commands,
     mut download_slippy_tile_messages: MessageWriter<DownloadSlippyTilesMessage>,
 ) {
-    commands.spawn(Camera2d::default());
+    commands.spawn(Camera2d);
     info!(
         "Requesting slippy tile for latitude/longitude: {:?}",
         (LATITUDE, LONGITUDE)


### PR DESCRIPTION
Hello,

Currently, we don't run `cargo clippy` for example code. This PR enables these checks on CI and fixes all warnings reported by `cargo clippy`.